### PR TITLE
Fix relative file paths for social icons

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -59,9 +59,9 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui quam. Aliquam a mi ac purus eleifend pretium. Donec rutrum accumsan odio, sed varius turpis facilisis commodo. Cras imperdiet ultricies ultrices. Proin placerat scelerisque tristique. Mauris quis blandit lacus. Donec vitae fringilla sapien. Donec purus erat, imperdiet vel consequat nec, euismod ac nisi. Ut et lectus ut elit porttitor hendrerit. Curabitur quis varius diam, id sagittis velit. Pellentesque quis vestibulum libero, rhoncus rhoncus massa. Mauris nec quam diam. Phasellus ullamcorper eget lectus vel egestas. Nam vitae felis tristique justo euismod laoreet at interdum tortor. Fusce vitae erat eu sem dignissim dapibus. Vivamus scelerisque dolor nec est aliquet, vel mollis enim semper.</p>
         <!-- social media icon grid -->
         <div class="row social">
-          <div class="col-xs-4"><a href="http://www.facebook.com/andrew.luborsky" target="_blank" data-toggle="tooltip" data-placement="top" title="Facebook"><img class="img-social" src="../images/social/fb.png"></a></div>
-          <div class="col-xs-4"><a href="http://twitter.com/aluborsky" target="_blank" data-toggle="tooltip" data-placement="top" title="Twitter"><img class="img-social" src="../images/social/twitter.png"></div>
-          <div class="col-xs-4"><a href="https://ca.linkedin.com/pub/andrew-luborsky/33/167/839" target="_blank" data-toggle="tooltip" data-placement="top" title="LinkedIn"><img class="img-social" src="../images/social/linkedin.png"></a></div>
+          <div class="col-xs-4"><a href="http://www.facebook.com/andrew.luborsky" target="_blank" data-toggle="tooltip" data-placement="top" title="Facebook"><img class="img-social" src="images/social/fb.png"></a></div>
+          <div class="col-xs-4"><a href="http://twitter.com/aluborsky" target="_blank" data-toggle="tooltip" data-placement="top" title="Twitter"><img class="img-social" src="images/social/twitter.png"></div>
+          <div class="col-xs-4"><a href="https://ca.linkedin.com/pub/andrew-luborsky/33/167/839" target="_blank" data-toggle="tooltip" data-placement="top" title="LinkedIn"><img class="img-social" src="images/social/linkedin.png"></a></div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
You had relative paths to your social icon images (`../images/whatever.png`), which weren't working when you deployed. Compare the lines changed here to all of the other image paths in your design.
